### PR TITLE
Add Boards Manager install support

### DIFF
--- a/package_NicoHood_HoodLoader2_index.json
+++ b/package_NicoHood_HoodLoader2_index.json
@@ -1,0 +1,50 @@
+{
+  "packages": [
+    {
+      "name": "HoodLoader2",
+      "maintainer": "NicoHood",
+      "websiteURL": "https://github.com/NicoHood/HoodLoader2",
+      "email": "",
+      "help": {
+        "online": ""
+      },
+      "platforms": [
+        {
+          "name": "HoodLoader2",
+          "architecture": "avr",
+          "version": "2.0.4",
+          "category": "HoodLoader2",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/NicoHood/HoodLoader2/releases/download/2.0.4/2.0.4-boards_manager.zip",
+          "archiveFileName": "2.0.4-boards_manager.zip",
+          "checksum": "SHA-256:743dd8d9154638a7f77b60379cd3dea6395c19791e99cbd054ef5a549197533e",
+          "size": "3315537",
+          "boards": [
+            {"name": "16u2"},
+            {"name": "32u2"},
+            {"name": "8u2"},
+            {"name": "at90usb162"},
+            {"name": "Original 16u2 DFU Firmware"},
+            {"name": "Arduino Uno HID-Bridge"},
+            {"name": "Arduino Mega 2560 HID-Bridge"}
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "4.8.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.0.1-arduino5"
+            }
+          ]
+        }
+      ],
+      "tools": []
+    }
+  ]
+}


### PR DESCRIPTION
- Boards Manager install URL for testing: https://raw.githubusercontent.com/per1234/HoodLoader2/per1234-boards-manager-support-test/package_NicoHood_HoodLoader2_index.json This is a temporary implementation and is only to be used for initial testing.

- You must add the file: https://github.com/per1234/HoodLoader2/releases/download/2.0.4/2.0.4-boards_manager.zip to your release 2.0.4.

- Your Boards Manager install URL: https://raw.githubusercontent.com/NicoHood/HoodLoader2/master/package_NicoHood_HoodLoader2_index.json You may want to add it to the installation section of your wiki, https://github.com/arduino/Arduino/wiki/Unofficial-list-of-3rd-party-boards-support-urls, and http://playground.arduino.cc/Main/ArduinoCoreHardware#Bootloader

![hoodloader2](https://cloud.githubusercontent.com/assets/8572152/7892063/8cc2f4dc-0606-11e5-9c3e-206db8cd9028.gif)
