### PR TITLE
Add v2.0.5 to Boards Manager JSON file

### DIFF
--- a/package_NicoHood_HoodLoader2_index.json
+++ b/package_NicoHood_HoodLoader2_index.json
@@ -13,7 +13,7 @@
           "name": "HoodLoader2",
           "architecture": "avr",
           "version": "2.0.4",
-          "category": "HoodLoader2",
+          "category": "Contributed",
           "help": {
             "online": ""
           },
@@ -29,6 +29,41 @@
             {"name": "Original 16u2 DFU Firmware"},
             {"name": "Arduino Uno HID-Bridge"},
             {"name": "Arduino Mega 2560 HID-Bridge"}
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "4.8.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.0.1-arduino5"
+            }
+          ]
+        },
+        {
+          "name": "HoodLoader2",
+          "architecture": "avr",
+          "version": "2.0.5",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/NicoHood/HoodLoader2/releases/download/2.0.5/2.0.5-boards_manager.zip",
+          "archiveFileName": "2.0.5-boards_manager.zip",
+          "checksum": "SHA-256:89c8778096ff13daefd4a8a734c9afc948b242c093d3b934278e9ba160740fa2",
+          "size": "2916947",
+          "boards": [
+            {"name": "16u2"},
+            {"name": "32u2"},
+            {"name": "8u2"},
+            {"name": "at90usb82"},
+            {"name": "at90usb162"},
+            {"name": "32u4"},
+            {"name": "Uno"},
+            {"name": "Mega 2560"}
           ],
           "toolsDependencies": [
             {


### PR DESCRIPTION
- Boards Manager URL for testing: https://raw.githubusercontent.com/per1234/HoodLoader2/BM-test/package_NicoHood_HoodLoader2_index.json
  - Using Arduino IDE 1.6.6 if you don't already have the previous version of HoodLoader2 installed via Boards Manager you may need to open Boards Manager twice before the HoodLoader2 entry will appear(https://github.com/arduino/Arduino/issues/3795)
  - If you're still having the problem with the optiboot download failing(https://github.com/arduino/Arduino/issues/3861) then that may cause the IDE to cancel download of the HoodLoader2 JSON file so you may need to temporarily remove the optiboot URL(or maybe just move it to the end of the URL list?).
  - Compile fails with HoodLoader 16u2, etc. using Arduino IDE 1.6.5r5 but I'm guessing this is expected behavior because HoodLoader 2.0.5 requires Arduino IDE 1.6.6.
- You must  create a 2.0.5 release with the installation archive file: https://github.com/per1234/HoodLoader2/releases/download/2.0.5/2.0.5-boards_manager.zip
- I have updated the category value according to the [specification](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.6.x---package_index.json-format-specification).

I'm happy to make any changes, just let me know.
